### PR TITLE
Add dist-tag functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-# 1.0.0
-
-- Initial version of `safe-publish` script.
-
 # 1.1.0
 
 - Add `--tag` flag to append dist-tags to publish command.
+
+# 1.0.0
+
+- Initial version of `safe-publish` script.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 # 1.0.0
 
 - Initial version of `safe-publish` script.
+
+# 1.1.0
+
+- Add `--tag` flag to append dist-tags to publish command.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ These values are optional and allow to configure the publication:
     "registry": "http://registry.url"
   }
   ```
+- `tag` (string): publish the package with a dist-tag  (see [npm-dist-tag](https://docs.npmjs.com/cli/dist-tag) ).
 - `force` (boolean): force the publication despite the fact that the package could exist.
   - It implies that the process could fail.
 - `dry-run` (boolean): for testing purposes, it does not try to publish the package.
@@ -70,6 +71,7 @@ Options and aliases:
   --version       Show version number                                  [boolean]
   --help          Show help                                            [boolean]
   -r, --registry  Override default registry                             [string]
+  -t, --tag       Publish with dist-tag                                 [string]
   -f, --force     Force publication                   [boolean] [default: false]
   -d, --dry-run   Test publication process            [boolean] [default: false]
   -s, --silent    Disable log output                  [boolean] [default: false]

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,8 +6,9 @@ const { red, bold } = require('chalk');
 const publish = require('../publish.js');
 const logger = require('../lib/logger');
 
-const { argv: { registry, force, dryRun, silent } } = yargs
+const { argv: { registry, tag, force, dryRun, silent } } = yargs
   .string('registry').alias('r', 'registry').describe('registry', 'Override default registry')
+  .string('tag').alias('t', 'tag').describe('tag', 'Publish with "--tag <TAG>"')
   .boolean('force').alias('f', 'force').default('force', false).describe('force', 'Force publication')
   .boolean('dry-run').alias('d', 'dry-run').default('dry-run', false).describe('dry-run', 'Test publication process')
   .boolean('silent').alias('s', 'silent').default('silent', false).describe('silent', 'Disable log output')
@@ -21,6 +22,7 @@ publish({
   name,
   version,
   registry,
+  tag,
   force,
   dryRun,
   silent
@@ -28,7 +30,7 @@ publish({
 .catch((error) => {
   const log = logger.create({ silent });
 
-  log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) }`);
+  log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${tag && 'with tag ' + bold(red(tag)) || ''}`);
   log.error(error);
 
   process.exit(-1);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,7 +30,7 @@ publish({
 .catch((error) => {
   const log = logger.create({ silent });
 
-  log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${tag && 'with tag ' + bold(red(tag)) || ''}`);
+  log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${ tag ? `with tag ${ bold(red(tag)) }` : '' }`);
   log.error(error);
 
   process.exit(-1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-publish",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Safe NPM package publication",
   "license": "MIT",
   "homepage": "https://github.com/adidas/safe-publish#readme",

--- a/publish.js
+++ b/publish.js
@@ -8,7 +8,7 @@ const resultCode = {
   ERROR: -1,
   SAME_VERSION: 0,
   NEW_VERSION: 1,
-  NEW_PACKAGE: 2
+  NEW_PACKAGE: 2,
 };
 
 /**
@@ -20,15 +20,15 @@ const resultCode = {
 function find({ cwd, name, version, registry }) {
   const args = [];
 
-  registry && args.push(`--registry ${ registry }`);
+  registry && args.push(`--registry ${registry}`);
 
-  return exec(`npm view ${ name }@${ version } version ${ args.join(' ') }`, { cwd })
+  return exec(`npm view ${name}@${version} version ${args.join(' ')}`, { cwd })
     .then(({ stdout }) => {
       const sameVersion = stdout.trim() === version;
 
       return resultCode[sameVersion ? 'SAME_VERSION' : 'NEW_VERSION'];
     })
-    .catch((error) => {
+    .catch(error => {
       const commandError = !~error.message.indexOf('E404');
 
       if (commandError) {
@@ -47,51 +47,54 @@ function find({ cwd, name, version, registry }) {
 function publish({ cwd, registry, tag, dryRun, code }) {
   const args = [];
 
-  tag && args.push(`--tag ${ tag }`);
-  registry && args.push(`--registry ${ registry }`);
+  tag && args.push(`--tag ${tag}`);
+  registry && args.push(`--registry ${registry}`);
   dryRun && args.push('--dry-run');
 
-  return exec(`npm publish ${ args.join(' ') }`, { cwd }).then(() => code);
+  return exec(`npm publish ${args.join(' ')}`, { cwd }).then(() => code);
 }
 
 module.exports = function({ cwd, name, version, registry, tag, force, dryRun, silent }) {
   const log = logger.create({ silent });
 
   return find({ cwd, name, version, registry })
-    .then((code) => {
+    .then(code => {
       if (!force && code === resultCode.SAME_VERSION) {
-        log.info(`Package ${ bold(name) } is up-to-date, no more action required`);
+        log.info(`Package ${bold(name)} is up-to-date, no more action required`);
         process.exit(resultCode.SAME_VERSION);
       }
 
       return code;
     })
-    .then((code) =>
+    .then(code =>
       publish({
         code,
         cwd,
         registry,
         tag,
-        dryRun
-      }))
-    .then((code) => {
+        dryRun,
+      }),
+    )
+    .then(code => {
       if (code === resultCode.NEW_VERSION) {
         log.info(
-          `Package ${ bold(blue(name)) } has been updated to v${ bold(blue(version)) } ${ (tag &&
-            `with tag${ bold(green(tag)) }`) ||
-            '' }`
+          `Package ${bold(blue(name))} has been updated to v${bold(blue(version))} ${
+            tag ? `with tag${bold(green(tag))}` : ''
+          }`,
         );
       } else {
         log.info(
-          `Package ${ bold(green(name)) } has been created with v${ bold(green(version)) } ${ (tag &&
-            `with tag${ bold(green(tag)) }`) ||
-            '' }`
+          `Package ${bold(green(name))} has been created with v${bold(green(version))} ${
+            tag ? `with tag${bold(green(tag))}` : ''
+          }`,
         );
       }
     })
-    .catch((error) => {
+    .catch(error => {
       log.error(
-        `Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${ (tag && `with tag${ bold(red(tag)) }`) || '' } `
+        `Error publishing ${bold(red(name))} to v${bold(red(version))} ${
+          tag ? `with tag${bold(red(tag))}` : ''
+        } `,
       );
       log.error(error);
 

--- a/publish.js
+++ b/publish.js
@@ -44,15 +44,14 @@ function find({ cwd, name, version, registry }) {
  * @param {number} code - Status code of the package (existing/new).
  * @returns {Promise<number>} Status code of the package (existing/new).
  */
-function publish({ cwd, registry, tag, public, dryRun, code }) {
+function publish({ cwd, registry, tag, dryRun, code }) {
   const args = [];
 
-  tag && args.push(`--tag ${tag}`)
+  tag && args.push(`--tag ${ tag }`);
   registry && args.push(`--registry ${ registry }`);
   dryRun && args.push('--dry-run');
-console.log(`npm publish ${ args.join(' ') }`)
-  return exec(`npm publish ${ args.join(' ') }`, { cwd })
-    .then(() => code);
+
+  return exec(`npm publish ${ args.join(' ') }`, { cwd }).then(() => code);
 }
 
 module.exports = function({ cwd, name, version, registry, tag, force, dryRun, silent }) {
@@ -62,28 +61,38 @@ module.exports = function({ cwd, name, version, registry, tag, force, dryRun, si
     .then((code) => {
       if (!force && code === resultCode.SAME_VERSION) {
         log.info(`Package ${ bold(name) } is up-to-date, no more action required`);
-
         process.exit(resultCode.SAME_VERSION);
       }
 
       return code;
     })
-    .then((code) => publish({
-      code,
-      cwd,
-      registry,
-      tag,
-      dryRun
-    }))
+    .then((code) =>
+      publish({
+        code,
+        cwd,
+        registry,
+        tag,
+        dryRun
+      }))
     .then((code) => {
       if (code === resultCode.NEW_VERSION) {
-        log.info(`Package ${ bold(blue(name)) } has been updated to v${ bold(blue(version)) } ${tag && 'with tag' + bold(green(tag)) || ''}`);
+        log.info(
+          `Package ${ bold(blue(name)) } has been updated to v${ bold(blue(version)) } ${ (tag &&
+            `with tag${ bold(green(tag)) }`) ||
+            '' }`
+        );
       } else {
-        log.info(`Package ${ bold(green(name)) } has been created with v${ bold(green(version)) } ${tag && 'with tag' + bold(green(tag)) || ''}`);
+        log.info(
+          `Package ${ bold(green(name)) } has been created with v${ bold(green(version)) } ${ (tag &&
+            `with tag${ bold(green(tag)) }`) ||
+            '' }`
+        );
       }
     })
     .catch((error) => {
-      log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${tag && 'with tag' + bold(red(tag)) || ''} `);
+      log.error(
+        `Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${ (tag && `with tag${ bold(red(tag)) }`) || '' } `
+      );
       log.error(error);
 
       process.exit(resultCode.ERROR);

--- a/publish.js
+++ b/publish.js
@@ -8,7 +8,7 @@ const resultCode = {
   ERROR: -1,
   SAME_VERSION: 0,
   NEW_VERSION: 1,
-  NEW_PACKAGE: 2,
+  NEW_PACKAGE: 2
 };
 
 /**
@@ -20,15 +20,15 @@ const resultCode = {
 function find({ cwd, name, version, registry }) {
   const args = [];
 
-  registry && args.push(`--registry ${registry}`);
+  registry && args.push(`--registry ${ registry }`);
 
-  return exec(`npm view ${name}@${version} version ${args.join(' ')}`, { cwd })
+  return exec(`npm view ${ name }@${ version } version ${ args.join(' ') }`, { cwd })
     .then(({ stdout }) => {
       const sameVersion = stdout.trim() === version;
 
       return resultCode[sameVersion ? 'SAME_VERSION' : 'NEW_VERSION'];
     })
-    .catch(error => {
+    .catch((error) => {
       const commandError = !~error.message.indexOf('E404');
 
       if (commandError) {
@@ -47,54 +47,51 @@ function find({ cwd, name, version, registry }) {
 function publish({ cwd, registry, tag, dryRun, code }) {
   const args = [];
 
-  tag && args.push(`--tag ${tag}`);
-  registry && args.push(`--registry ${registry}`);
+  tag && args.push(`--tag ${ tag }`);
+  registry && args.push(`--registry ${ registry }`);
   dryRun && args.push('--dry-run');
 
-  return exec(`npm publish ${args.join(' ')}`, { cwd }).then(() => code);
+  return exec(`npm publish ${ args.join(' ') }`, { cwd }).then(() => code);
 }
 
 module.exports = function({ cwd, name, version, registry, tag, force, dryRun, silent }) {
   const log = logger.create({ silent });
 
   return find({ cwd, name, version, registry })
-    .then(code => {
+    .then((code) => {
       if (!force && code === resultCode.SAME_VERSION) {
-        log.info(`Package ${bold(name)} is up-to-date, no more action required`);
+        log.info(`Package ${ bold(name) } is up-to-date, no more action required`);
         process.exit(resultCode.SAME_VERSION);
       }
 
       return code;
     })
-    .then(code =>
+    .then((code) =>
       publish({
         code,
         cwd,
         registry,
         tag,
-        dryRun,
-      }),
-    )
-    .then(code => {
+        dryRun
+      }))
+    .then((code) => {
       if (code === resultCode.NEW_VERSION) {
         log.info(
-          `Package ${bold(blue(name))} has been updated to v${bold(blue(version))} ${
-            tag ? `with tag${bold(green(tag))}` : ''
-          }`,
+          `Package ${ bold(blue(name)) } has been updated to v${ bold(blue(version)) } ${
+            tag ? `with tag${ bold(green(tag)) }` : ''
+          }`
         );
       } else {
         log.info(
-          `Package ${bold(green(name))} has been created with v${bold(green(version))} ${
-            tag ? `with tag${bold(green(tag))}` : ''
-          }`,
+          `Package ${ bold(green(name)) } has been created with v${ bold(green(version)) } ${
+            tag ? `with tag${ bold(green(tag)) }` : ''
+          }`
         );
       }
     })
-    .catch(error => {
+    .catch((error) => {
       log.error(
-        `Error publishing ${bold(red(name))} to v${bold(red(version))} ${
-          tag ? `with tag${bold(red(tag))}` : ''
-        } `,
+        `Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${ tag ? `with tag${ bold(red(tag)) }` : '' } `
       );
       log.error(error);
 

--- a/publish.js
+++ b/publish.js
@@ -44,17 +44,18 @@ function find({ cwd, name, version, registry }) {
  * @param {number} code - Status code of the package (existing/new).
  * @returns {Promise<number>} Status code of the package (existing/new).
  */
-function publish({ cwd, registry, dryRun, code }) {
+function publish({ cwd, registry, tag, public, dryRun, code }) {
   const args = [];
 
+  tag && args.push(`--tag ${tag}`)
   registry && args.push(`--registry ${ registry }`);
   dryRun && args.push('--dry-run');
-
+console.log(`npm publish ${ args.join(' ') }`)
   return exec(`npm publish ${ args.join(' ') }`, { cwd })
     .then(() => code);
 }
 
-module.exports = function({ cwd, name, version, registry, force, dryRun, silent }) {
+module.exports = function({ cwd, name, version, registry, tag, force, dryRun, silent }) {
   const log = logger.create({ silent });
 
   return find({ cwd, name, version, registry })
@@ -71,17 +72,18 @@ module.exports = function({ cwd, name, version, registry, force, dryRun, silent 
       code,
       cwd,
       registry,
+      tag,
       dryRun
     }))
     .then((code) => {
       if (code === resultCode.NEW_VERSION) {
-        log.info(`Package ${ bold(blue(name)) } has been updated to v${ bold(blue(version)) }`);
+        log.info(`Package ${ bold(blue(name)) } has been updated to v${ bold(blue(version)) } ${tag && 'with tag' + bold(green(tag)) || ''}`);
       } else {
-        log.info(`Package ${ bold(green(name)) } has been created with v${ bold(green(version)) }`);
+        log.info(`Package ${ bold(green(name)) } has been created with v${ bold(green(version)) } ${tag && 'with tag' + bold(green(tag)) || ''}`);
       }
     })
     .catch((error) => {
-      log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) }`);
+      log.error(`Error publishing ${ bold(red(name)) } to v${ bold(red(version)) } ${tag && 'with tag' + bold(red(tag)) || ''} `);
       log.error(error);
 
       process.exit(resultCode.ERROR);


### PR DESCRIPTION
Adds a new command line flag and publish config option to enable npm publish 'dist-tag' functionality.

- `tag` (string): publish the package with a dist-tag  (see [npm-dist-tag](https://docs.npmjs.com/cli/dist-tag) ).